### PR TITLE
20862 update deps

### DIFF
--- a/arvados-google-api-client.gemspec
+++ b/arvados-google-api-client.gemspec
@@ -9,10 +9,10 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.authors = ["Bob Aman", "Steven Bazyl"]
   s.license = "Apache-2.0"
-  s.description = "The Google API Ruby Client makes it trivial to discover and access supported APIs."
-  s.email = "sbazyl@google.com"
+  s.description = "Fork of google-api-client used by Ruby-based Arvados components."
+  s.email = "dev@arvados.org"
   s.extra_rdoc_files = ["README.md"]
-  s.files = %w(google-api-client.gemspec Rakefile LICENSE CHANGELOG.md README.md Gemfile)
+  s.files = %w(arvados-google-api-client.gemspec Rakefile LICENSE CHANGELOG.md README.md Gemfile)
   s.files += Dir.glob("lib/**/*.rb")
   s.files += Dir.glob("lib/cacerts.pem")
   s.files += Dir.glob("spec/**/*.{rb,opts}")
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.files += Dir.glob("website/**/*")
   s.homepage = "https://github.com/arvados/google-api-ruby-client/"
   s.rdoc_options = ["--main", "README.md"]
-  s.summary = "The Google API Ruby Client makes it trivial to discover and access Google's REST APIs."
+  s.summary = "Fork of google-api-client used by Ruby-based Arvados components."
 
   s.add_runtime_dependency 'addressable', '~> 2.3'
   s.add_runtime_dependency 'signet', '~> 0.6'

--- a/arvados-google-api-client.gemspec
+++ b/arvados-google-api-client.gemspec
@@ -24,15 +24,16 @@ Gem::Specification.new do |s|
   s.summary = "Fork of google-api-client used by Ruby-based Arvados components."
 
   s.add_runtime_dependency 'addressable', '~> 2.3'
-  s.add_runtime_dependency 'signet', '~> 0.6'
-  s.add_runtime_dependency 'faraday', '~> 0.9'
-  s.add_runtime_dependency 'googleauth', '~> 0.3'
+  s.add_runtime_dependency 'signet', '~> 1.0'
+  s.add_runtime_dependency 'faraday', '~> 2.0'
+  s.add_runtime_dependency 'faraday-multipart', '~> 1.0'
+  s.add_runtime_dependency 'googleauth', '~> 1.0'
   s.add_runtime_dependency 'multi_json', '~> 1.10'
   s.add_runtime_dependency 'autoparse', '~> 0.3'
   s.add_runtime_dependency 'extlib', '~> 0.9'
   s.add_runtime_dependency 'launchy', '~> 2.4'
   s.add_runtime_dependency 'retriable', '~> 1.4'
-  s.add_runtime_dependency 'activesupport', '>= 3.2', '< 5.3'
+  s.add_runtime_dependency 'activesupport', '>= 3.2', '< 8.0'
 
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'yard', '~> 0.8'

--- a/lib/google/api_client/media.rb
+++ b/lib/google/api_client/media.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 require 'google/api_client/reference'
+require 'faraday/multipart'
 
 module Google
   class APIClient
@@ -21,7 +22,7 @@ module Google
     # @see Faraday::UploadIO
     # @example
     #   media = Google::APIClient::UploadIO.new('mymovie.m4v', 'video/mp4')
-    class UploadIO < Faraday::UploadIO
+    class UploadIO < Faraday::Multipart::FilePart
       
       # @return [Fixnum] Size of chunks to upload. Default is nil, meaning upload the entire file in a single request
       attr_accessor :chunk_size

--- a/lib/google/api_client/request.rb
+++ b/lib/google/api_client/request.rb
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 require 'faraday'
-require 'faraday/request/multipart'
 require 'compat/multi_json'
 require 'addressable/uri'
 require 'stringio'
@@ -279,32 +278,7 @@ module Google
       # @option options [#read, #to_str] :body
       #   Raw body to send in POST/PUT requests
       def initialize_media_upload(options)
-        self.media = options[:media]
-        case self.upload_type
-        when "media"
-          if options[:body] || options[:body_object]
-            raise ArgumentError, "Can not specify body & body object for simple uploads"
-          end
-          self.headers['Content-Type'] ||= self.media.content_type
-          self.headers['Content-Length'] ||= self.media.length.to_s
-          self.body = self.media
-        when "multipart"
-          unless options[:body_object]
-            raise ArgumentError, "Multipart requested but no body object"
-          end
-          metadata = StringIO.new(serialize_body(options[:body_object]))
-          build_multipart([Faraday::UploadIO.new(metadata, 'application/json', 'file.json'), self.media])
-        when "resumable"
-          file_length = self.media.length
-          self.headers['X-Upload-Content-Type'] = self.media.content_type
-          self.headers['X-Upload-Content-Length'] = file_length.to_s
-          if options[:body_object]
-            self.headers['Content-Type'] ||= 'application/json'
-            self.body = serialize_body(options[:body_object])
-          else
-            self.body = ''
-          end
-        end
+        raise "not supported"
       end
 
       ##
@@ -319,13 +293,7 @@ module Google
       # @param [String] boundary
       #   Boundary for separating each part of the message
       def build_multipart(parts, mime_type = 'multipart/related', boundary = MULTIPART_BOUNDARY)
-        env = Faraday::Env.new
-        env.request = Faraday::RequestOptions.new
-        env.request.boundary = boundary
-        env.request_headers = {'Content-Type' => "#{mime_type};boundary=#{boundary}"}
-        multipart = Faraday::Request::Multipart.new
-        self.body = multipart.create_multipart(env, parts.map {|part| [nil, part]})
-        self.headers.update(env[:request_headers])
+        raise "not supported"
       end
 
       ##

--- a/lib/google/api_client/version.rb
+++ b/lib/google/api_client/version.rb
@@ -19,7 +19,7 @@ module Google
       MAJOR = 0
       MINOR = 8
       TINY  = 7
-      PATCH = 4
+      PATCH = 5
       STRING = [MAJOR, MINOR, TINY, PATCH].compact.join('.')
     end
   end


### PR DESCRIPTION
Remove functionality that relies on old versions of faraday and signet, in order to make the gem usable alongside newer versions of Ruby and Rails.